### PR TITLE
Change listener to abstract class.

### DIFF
--- a/ahp/src/main/java/com/daasuu/ahp/AnimateHorizontalProgressBar.java
+++ b/ahp/src/main/java/com/daasuu/ahp/AnimateHorizontalProgressBar.java
@@ -223,16 +223,12 @@ public class AnimateHorizontalProgressBar extends ProgressBar {
         void onAnimationEnd(int progress, int max);
     }
 
-    private class SimpleAnimatorListener implements Animator.AnimatorListener {
+    private abstract class SimpleAnimatorListener implements Animator.AnimatorListener {
         @Override
-        public void onAnimationStart(Animator animation) {
-
-        }
+        public abstract void onAnimationStart(Animator animation);
 
         @Override
-        public void onAnimationEnd(Animator animation) {
-
-        }
+        public abstract void onAnimationEnd(Animator animation);
 
         @Override
         public void onAnimationCancel(Animator animation) {


### PR DESCRIPTION
The `SimpleAnimatorListener` is only used in `setUpAnimator()`.

``` java
    private void setUpAnimator() {
        mProgressAnimator = new ValueAnimator();
        mProgressAnimator.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
            @Override
            public void onAnimationUpdate(ValueAnimator animation) {
                AnimateHorizontalProgressBar.super.setProgress((Integer) animation.getAnimatedValue());
            }
        });
        mProgressAnimator.addListener(new SimpleAnimatorListener() {
            @Override
            public void onAnimationStart(Animator animation) {
                isAnimating = true;
                if (mAnimateProgressListener != null) {
                    mAnimateProgressListener.onAnimationStart(getProgress(), getMax());
                }
            }

            @Override
            public void onAnimationEnd(Animator animation) {
                isAnimating = false;
                if (mAnimateProgressListener != null) {
                    mAnimateProgressListener.onAnimationEnd(getProgress(), getMax());
                }
            }
        });
```

This listener class should implements `onAnimationStart()` and `onAnimationEnd()`, so I change these method to abstract.

Could you review it? Thanks.
